### PR TITLE
handle null values from connect data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: java
+dist: trusty
+branches:
+  only:
+    - master
+jdk:
+  - openjdk8
+sudo: required
+install:
+  mvn install --batch-mode -DskipTests=true -Dmaven.javadoc.skip=true -Dsource.skip=true | pv -fbi 60 > mvn_install.log || (cat mvn_install.log && false)
+jobs:
+  include:
+    - stage: test
+      name: "Check"
+      script: mvn verify --batch-mode javadoc:javadoc
+    - stage: publish
+      if: branch = master AND type = push OR commit_message = PUBLISH
+      name: "Publish"
+      script: mvn deploy -DskipTests=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
   include:
     - stage: test
       name: "Check"
-      script: mvn verify --batch-mode javadoc:javadoc
+      script: mvn verify --batch-mode javadoc:javadoc -Dgpg.skip
     - stage: publish
       if: branch = master AND type = push OR commit_message = PUBLISH
       name: "Publish"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jdk:
   - openjdk8
 sudo: required
 install:
-  mvn install --batch-mode -DskipTests=true -Dmaven.javadoc.skip=true -Dsource.skip=true | pv -fbi 60 > mvn_install.log || (cat mvn_install.log && false)
+  mvn install --batch-mode -DskipTests=true -Dmaven.javadoc.skip=true -Dsource.skip=true -B -V -Dgpg.skip
 jobs:
   include:
     - stage: test

--- a/pom.xml
+++ b/pom.xml
@@ -50,9 +50,9 @@
     </developers>
 
     <scm>
-        <connection>scm:git:git://github.com/blueapron/kafka-connect-protobuf-converter.git</connection>
-        <developerConnection>scm:git:git@github.com:blueapron/kafka-connect-protobuf-converter.git</developerConnection>
-        <url>https://github.com/blueapron/kafka-connect-protobuf-converter/tree/master</url>
+        <connection>scm:git:git://github.com/optimizely/kafka-connect-protobuf-converter.git</connection>
+        <developerConnection>scm:git:git@github.com:optimizely/kafka-connect-protobuf-converter.git</developerConnection>
+        <url>https://github.com/optimizely/kafka-connect-protobuf-converter/tree/master</url>
         <tag>HEAD</tag>
     </scm>
 
@@ -94,16 +94,23 @@
 
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <id>s3-remote-repository-snapshot</id>
+            <url>s3://optimizely-maven</url>
         </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>s3-remote-repository-release</id>
+            <url>s3://optimizely-maven</url>
         </repository>
     </distributionManagement>
 
     <build>
+        <extensions>
+            <extension>
+                <groupId>org.kuali.maven.wagons</groupId>
+                <artifactId>maven-s3-wagon</artifactId>
+                <version>1.2.1</version>
+            </extension>
+        </extensions>
         <plugins>
             <plugin>
                 <artifactId>maven-deploy-plugin</artifactId>
@@ -122,15 +129,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
                 <version>1.6</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
             <plugin>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-connect-maven-plugin</artifactId>
-                <version>0.11.2</version>
+                <version>0.11.3</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -145,17 +145,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.7</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>2.2.1</version>

--- a/src/main/java/com/blueapron/connect/protobuf/ProtobufData.java
+++ b/src/main/java/com/blueapron/connect/protobuf/ProtobufData.java
@@ -422,6 +422,10 @@ class ProtobufData {
   }
 
   private void fromConnectData(com.google.protobuf.GeneratedMessageV3.Builder builder, Field field, Object value) {
+    if (value == null) {
+      return; // Ignore missing values
+    }
+
     final String protobufFieldName = getProtoFieldName(builder.getDescriptorForType().getFullName(), field.name());
     final Descriptors.FieldDescriptor fieldDescriptor = builder.getDescriptorForType().findFieldByName(protobufFieldName);
     if (fieldDescriptor == null) {

--- a/src/test/java/com/blueapron/connect/protobuf/ProtobufDataTest.java
+++ b/src/test/java/com/blueapron/connect/protobuf/ProtobufDataTest.java
@@ -761,6 +761,17 @@ public class ProtobufDataTest {
   }
 
   @Test
+  public void testFromConnectNullTimestampOptionalField() throws ParseException, InvalidProtocolBufferException {
+    Schema timestampSchema = org.apache.kafka.connect.data.Timestamp.builder().optional().build();
+
+    Struct struct = wrapValueStruct(timestampSchema.schema(), null);
+
+    ProtobufData protobufData = new ProtobufData(TimestampValueOuterClass.TimestampValue.class, "legacy-name");
+    Message message = TimestampValueOuterClass.TimestampValue.parseFrom(protobufData.fromConnectData(struct));
+    assertEquals(0, message.getAllFields().size());
+  }
+
+  @Test
   public void testFromConnectDate() throws ParseException, InvalidProtocolBufferException {
     Schema dateSchema = org.apache.kafka.connect.data.Date.builder().optional().build();
 
@@ -895,6 +906,7 @@ public class ProtobufDataTest {
     java.util.Date value = sdf.parse("2017/09/18");
 
     Struct struct = new Struct(getExpectedNestedTestProtoSchema());
+    struct.put("user_id", NestedTestProtoOuterClass.UserId.newBuilder().setBaComUserId("ba_com_user_id"));
     struct.put("updated_at", value);
 
     ProtobufData protobufData = new ProtobufData(NestedTestProto.class, LEGACY_NAME);


### PR DESCRIPTION
Ignore setting fields whose values are null. Blueapron's kafka-connect-protobuf-converter fails with NullPointerException if the any of the field's value is null. For instance, we observed the following error in stream service postgres kafka connect sync when the int64 (logical Timestamp type) field's value is null.

```
org.apache.kafka.connect.errors.ConnectException: Tolerance exceeded in error handler
        at org.apache.kafka.connect.runtime.errors.RetryWithToleranceOperator.execAndHandleError(RetryWithToleranceOperator.java:178)
        at org.apache.kafka.connect.runtime.errors.RetryWithToleranceOperator.execute(RetryWithToleranceOperator.java:104)
        at org.apache.kafka.connect.runtime.WorkerSourceTask.convertTransformedRecord(WorkerSourceTask.java:284)
        at org.apache.kafka.connect.runtime.WorkerSourceTask.sendRecords(WorkerSourceTask.java:309)
        at org.apache.kafka.connect.runtime.WorkerSourceTask.execute(WorkerSourceTask.java:234)
        at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:177)
        at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:227)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.NullPointerException
        at org.apache.kafka.connect.data.Timestamp.fromLogical(Timestamp.java:51)
        at com.blueapron.connect.protobuf.ProtobufData.fromConnectData(ProtobufData.java:452)
        at com.blueapron.connect.protobuf.ProtobufData.fromConnectData(ProtobufData.java:418)
        at com.blueapron.connect.protobuf.ProtobufConverter.fromConnectData(ProtobufConverter.java:60)
        at org.apache.kafka.connect.runtime.WorkerSourceTask.lambda$convertTransformedRecord$2(WorkerSourceTask.java:284)
        at org.apache.kafka.connect.runtime.errors.RetryWithToleranceOperator.execAndRetry(RetryWithToleranceOperator.java:128)
        at org.apache.kafka.connect.runtime.errors.RetryWithToleranceOperator.execAndHandleError(RetryWithToleranceOperator.java:162)
        ... 11 more
```